### PR TITLE
use 'festival --pipe' to decrease latency

### DIFF
--- a/mopidy_ttsgpio/frontend.py
+++ b/mopidy_ttsgpio/frontend.py
@@ -15,7 +15,7 @@ class TtsGpio(pykka.ThreadingActor, core.CoreListener):
 
     def __init__(self, config, core):
         super(TtsGpio, self).__init__()
-        self.tts = TTS(self, config)
+        self.tts = TTS()
         self.menu = False
         self.core = core
         self.main_menu = MainMenu(self)

--- a/mopidy_ttsgpio/tts.py
+++ b/mopidy_ttsgpio/tts.py
@@ -1,17 +1,20 @@
 import os
 from threading import Thread
+import time
 
 music_level = 30
 
 
 class TTS():
+	def __init__(self):
+		self.t = Thread(target=self.speak_text_thread)
+		self.t.start()
 
-    def __init__(self, frontend, config):
-        self.frontend = frontend
+	def speak_text(self, text):
+		s='(SayText "{0}")\n'.format(text)
+		self.p.stdin.write(s)
 
-    def speak_text(self, text):
-        t = Thread(target=self.speak_text_thread, args=(text,))
-        t.start()
-
-    def speak_text_thread(self, text):
-        os.system(' echo "' + text + '" | festival --tts')
+	def speak_text_thread(self):
+		self.p = subprocess.Popen('/usr/bin/festival --pipe'.split(),stdout=subprocess.PIPE, stderr=subprocess.PIPE, stdin=subprocess.PIPE)
+		while 1:
+			time.sleep(1)


### PR DESCRIPTION
instead of forking a new thread and launching a new process for each sentence, we launch festival in pipe mode and send sentences to its pipe.  This decreases the 'button to speech' latency on my Pi3 from about 3 seconds to under a second, probably closer to 500ms.